### PR TITLE
cordial v0.01.07

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rda filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ po/*~
 
 # RStudio Connect folder
 rsconnect/
+
+# Specific files
+data/crispr_DT.rda

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,15 +1,18 @@
 Package: cordial
-Title: A Pleasant Tonic For Convenient Correlation Analysis In R
-Version: 0.01.06
-Authors@R: 
-    person("Irbaz", "Badshah", , "i.badshah@qmul.ac.uk", 
-           role = c("aut", "cre"), comment = c(ORCID = "0000-0002-7545-3851"))
+Title: A Pleasant Tonic For Parallel Correlation Analysis In R
+Version: 0.01.07
+Authors@R: c(
+    person("Irbaz", "Badshah", , "i.badshah@qmul.ac.uk", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-7545-3851")),
+    person("Pedro", "Cutillas", , "p.cutillas@qmul.ac.uk", role = "aut",
+           comment = c(ORCID = "0000-0002-3426-2274"))
+  )
 Description: Computes pairwise Pearson's correlations of a dataset, or 
     specified targets simultaneously in parallel. Conveniently includes the 
     ability to filter the input dataset and select a subset of columns to 
     compute correlations. Outputs Pearson's product moment correlation 
-    coefficients, p-values, adjusted p-values, and observation counts in 
-    long-format.
+    coefficients, p-values, adjusted p-values, linear model slope and 
+    observation counts in long-format.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/cordial.R
+++ b/R/cordial.R
@@ -1,11 +1,11 @@
-#' cordial: A pleasant tonic for convenient correlation analysis in R
+#' cordial: A Pleasant Tonic For Parallel Correlation Analysis In R
 #'
 #' The \code{cordial} package provides functions to compute pairwise Pearson's
 #' correlations of a dataset, or specified targets simultaneously in parallel.
 #' Conveniently includes the ability to filter the input dataset and select a
 #' subset of columns to compute correlations. Outputs Pearson's product moment
-#' correlation coefficients, p-values, adjusted p-values, and observation
-#' counts in long-format.
+#' correlation coefficients, p-values, adjusted p-values, linear model slope
+#' and observation counts in long-format.
 #'
 #' @section \code{cordial} functions:
 #' \itemize{

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ Run: `devtools::install_github("CutillasLab/cordial@*release")`
    - *You may first need to install `devtools`: `install.packages("devtools")`*
 
 ## Notes
-  - The source files in `cordial/data/` only contain *EMPTY* placeholders, as the actual data files are too large to upload as source files to GitHub.
-  - The `.zip` and `.tar.gz` in the latest [release's](https://github.com/CutillasLab/cordial/releases/latest) assets *DOES* contain the actual data.
+  - The source files in `cordial/data/` does *NOT* contain the `crispr_DT` data, as it exceeds the GitHub file size limit.
+  - The `.tar.gz` in the latest [release's](https://github.com/CutillasLab/cordial/releases/latest) assets *DOES* contain the data.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cordial
-**A Pleasant Tonic For Convenient Correlation Analysis In R**
+**A Pleasant Tonic For Parallel Correlation Analysis In R**
 
 Computes pairwise Pearson's correlations of a dataset, or 
 specified targets simultaneously in parallel. Additionally, fits a 

--- a/cordial.Rproj
+++ b/cordial.Rproj
@@ -1,0 +1,22 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/data/cellmeta_DT.rda
+++ b/data/cellmeta_DT.rda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f83e15b602589b9876c1aa681106f12691862d58a1b9b351a1ffe53dc6dd2f2
+size 80358

--- a/data/rnai_DT.rda
+++ b/data/rnai_DT.rda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:395b59de7616f2b6493800875906524519adac6b4fb4498323b56d2117323453
+size 74535163

--- a/man/cordial.Rd
+++ b/man/cordial.Rd
@@ -3,14 +3,14 @@
 \docType{package}
 \name{cordial}
 \alias{cordial}
-\title{cordial: A pleasant tonic for convenient correlation analysis in R}
+\title{cordial: A Pleasant Tonic For Parallel Correlation Analysis In R}
 \description{
 The \code{cordial} package provides functions to compute pairwise Pearson's
 correlations of a dataset, or specified targets simultaneously in parallel.
 Conveniently includes the ability to filter the input dataset and select a
 subset of columns to compute correlations. Outputs Pearson's product moment
-correlation coefficients, p-values, adjusted p-values, and observation
-counts in long-format.
+correlation coefficients, p-values, adjusted p-values, linear model slope
+and observation counts in long-format.
 }
 \section{\code{cordial} functions}{
 


### PR DESCRIPTION
### cordial v0.01.07

1. Re-build 'data/*.rda' with usethis::use_data() as error on install from R console
2. crispr_DT added to .gitignore as exceeds GitHub file size limit (100 MB)
3. Use of [git LFS](https://git-lfs.com/)
4. Updated 'README'
5. Updated 'DESCRIPTION'
6. Updated 'R/cordial.R'
7. devtools::document()
8. New package build with devtools::build()